### PR TITLE
fix docs namespace mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ register_creator_reader_manual(L);
 Use in lua
 
 ```lua
-local creatorReader = cc.CreatorReader:createWithFilename('creator/CreatorSprites.ccreator')
+local creatorReader = creator.CreatorReader:createWithFilename('creator/CreatorSprites.ccreator')
 creatorReader:setup()
 local scene = creatorReader:getSceneGraph()
 cc.Director:getInstance():replaceScene(scene)


### PR DESCRIPTION
change `cc` to `creator`, https://github.com/cocos2d/cocos2d-x-docs/issues/126. code example is here:

https://github.com/minggo/cocos2d-x/blob/3ef7bd051f24de23767898b668c56cc34e7dee31/tests/lua-empty-test/src/mainscene.lua#L16