### PR TITLE
modify toggle children node remove logic

### DIFF
--- a/creator_project/packages/creator-luacpp-support/core/parser/Toggle.js
+++ b/creator_project/packages/creator-luacpp-support/core/parser/Toggle.js
@@ -42,6 +42,9 @@ class Toggle extends Node {
         }
 
         // remove Background and CheckMark
+        // on creator 1.9.x, checkmark and background is brother node, so we need remove both
+        Utils.remove_child_by_id(this, checkmark_component.node.__id__);
+        // on oldder version, checkmark is the child node of background, so only remove parent is ok
         Utils.remove_child_by_id(this, background_node_id);
 
         // 2nd: parse children


### PR DESCRIPTION
on creator 1.9.x, checkmark and background is brother node, so we need remove both
on older version, checkmark is the child node of background, so only remove parent is ok

I think remove checkmark and then remove background also works on older version. for existed the relation `toggle -> background -> checkmark.`